### PR TITLE
fix: migrate digest image to mitigate impact on policy changes on Chainguards Images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/go:1.20.5 AS builder
+FROM cgr.dev/chainguard/go@sha256:8ed3fdc8f6375a3fd84b4b8b696a2366c3a639931aab492d6f92ca917e726ad6 AS builder
 WORKDIR /go/src/github.com/toVersus/wbtemporal
 COPY go.* ./
 RUN go mod download


### PR DESCRIPTION
Fixes: #1 